### PR TITLE
Solved alignment issue in the online usernames tab (Green Dot)

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -182,7 +182,7 @@ socket.on("typing", (user) => {
 let addusertolist = (user) => {
   let item = document.createElement("li");
   item.style.color = (selfId) ? user.color : 'blue';
-  item.innerHTML = '<span class="dot"></span>' + user.name;
+  item.innerHTML = '<span class="dot"></span>' + '<div class="uname">'+user.name+'</div>';
   item.id = user.id
   item.onclick = handleOnlineClick.bind(null, user.id)
   online.appendChild(item);

--- a/public/main.css
+++ b/public/main.css
@@ -24,7 +24,7 @@ body {
 
 #header nav {
   right: 3rem;
-  top: 24px;
+  top: 36px;
   position: absolute;
 }
 
@@ -34,8 +34,8 @@ body {
 }
 
 #online li {
-  padding: 10px;
-  text-align: center;
+  padding: 10px 14px;
+  text-align: left;
   cursor: pointer;
 }
 
@@ -62,12 +62,12 @@ body {
   background-color: #1a4d5e;
   color: white;
   cursor: pointer;
-  padding: 18px;
-  width: 10rem;
+  padding: 15px;
+  width: 13rem;
   border: none;
-  text-align: left;
+  text-align: center;
   outline: none;
-  font-size: 15px;
+  font-size: 18px;
   text-align: center;
   border-radius: 20px;
 }
@@ -82,7 +82,7 @@ body {
   display: none;
   overflow: hidden;
   background-color: #f1f1f1;
-  width: 10rem;
+  width: 13rem;
   border-radius: 10px;
 }
 

--- a/public/main.css
+++ b/public/main.css
@@ -37,6 +37,9 @@ body {
   padding: 10px 14px;
   text-align: left;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+
 }
 
 #online li:hover {
@@ -84,6 +87,12 @@ body {
   background-color: #f1f1f1;
   width: 13rem;
   border-radius: 10px;
+  overflow-wrap: break-word
+}
+.uname{
+  width: 89%;
+  overflow-wrap: break-word;
+  display: inline-block;
 }
 
 div.content {


### PR DESCRIPTION
The new CSS involved resizing the collapsible button and the **li** items under it to accomodate long usernames without alignment issues of the online dot indicator.
The new alignment looks like this
![Screenshot from 2021-12-17 15-30-01](https://user-images.githubusercontent.com/74984914/146529981-90f84431-28ba-47d1-ad53-1af2519d74d3.png)
I have also changed the alignment from centered to left so that it looks more uniformly listed.