### PR TITLE
simple tag feature added

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -125,6 +125,15 @@ socket.on("chat message", (user, msg, time, toUser) => {
   if (user.id !== selfId) playSound('/notification.mp3')
   feedback.innerHTML = "";
 
+  //emiting a notification to a particular user if the msg has some person tagged
+  users.forEach((saved_user)=>{
+    if(msg.search("@"+saved_user.name)!==-1){
+      //push notification to that specific user
+      alert(saved_user.name + " you have been tagged!")
+    }
+
+  });
+
   // check if someone has set their name
   users.forEach((saved_user) => {
     if (saved_user.id === user.id) {


### PR DESCRIPTION
This feature helps users to tag another user online by using the @ symbol. When a person(for eg with user id: abcd) is being tagged, then all the online users will get a window prompt of the following message "  abcd you have been tagged!".

This feature can be improved, by making  the window prompt a desktop notification instead and also ensuring that this notification reaches the required client only( instead of getting sent to all the users)
